### PR TITLE
Inherit TryBuf from Buf

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ impl std::fmt::Display for ErrorKind {
 
 impl std::error::Error for ErrorKind {}
 
-pub trait TryBuf {
+pub trait TryBuf: Buf {
     define_try_get!(u16 u32 u64 u128 i16 i32 i64 i128 f32 f64);
     define_try_get!(@def_be u8 i8);
 


### PR DESCRIPTION
This allows to use Buf methods as well as automatically implement TryBuf in generic contexts.

For example, if I have `fn foo(buf: impl TryBuf) {}`, use `buf.take()` and try to use the resulting `Take<impl TryBuf>` as another `TryBuf`, before this PR that would fail in Rust because Rust can't prove that `Take<impl TryBuf>` implements `Buf`.